### PR TITLE
Lighten shop card component

### DIFF
--- a/client/src/components/pages/Account/TeamPage.jsx
+++ b/client/src/components/pages/Account/TeamPage.jsx
@@ -7,11 +7,13 @@ import BurgerMenuComp from "src/components/ui/Nav/BurgerMenuComp2";
 import bigCoinImage from "src/components/files/big-coin20.png";
 import ShopCard from "src/components/ui/Cards/ShopCard2";
 import axiosInstance from "src/axiosInstance";
+import { formatNumberWithSpaces } from 'src/utils';
 
 export default function TeamPage({ user, logoutHandler, updateUserCoins }) {
   const [teamMembers, setTeamMembers] = useState([]);
   const [teamCost, setTeamCost] = useState(0);
-  const [result, setResult] = useState(null);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [playerToSell, setPlayerToSell] = useState(null);
 
   useEffect(() => {
     if (!user) return;
@@ -26,6 +28,23 @@ export default function TeamPage({ user, logoutHandler, updateUserCoins }) {
       });
   }, [user]);
 
+  const handleClickOutside = (event) => {
+    if (event.target.classList.contains(styles.overlay)) {
+      setIsMenuOpen(false);
+    }
+  };
+
+
+  const openSellMenu = (player) => {
+    setPlayerToSell(player);
+    setIsMenuOpen(true);
+  };
+
+  const closeSellMenu = () => {
+    setIsMenuOpen(false);
+    setPlayerToSell(null);
+  }
+
   function calculateTeamCost(teamArray) {
     let cost = 0;
     teamArray.forEach((teamPlayer) => {
@@ -34,10 +53,10 @@ export default function TeamPage({ user, logoutHandler, updateUserCoins }) {
     setTeamCost(cost);
   }
 
-  async function sellPlayer(playerId, userId) {
+  async function sellPlayer() {
     try {
       const response = await axiosInstance.get(
-        `constract/checkPlayerInLiveRosters/${userId}/${playerId}`
+        `constract/checkPlayerInLiveRosters/${user.id}/${playerToSell.id}`
       );
       const result = response.data.result;
 
@@ -48,7 +67,7 @@ export default function TeamPage({ user, logoutHandler, updateUserCoins }) {
       }
 
       const sellResponse = await axiosInstance.post(
-        `/players/sell/${playerId}/${userId}`
+        `/players/sell/${playerToSell.id}/${user.id}`
       );
       console.log(sellResponse.data);
       updateUserCoins(sellResponse.data);
@@ -66,6 +85,8 @@ export default function TeamPage({ user, logoutHandler, updateUserCoins }) {
 
       alert(`Произошла ошибка при продаже игрока. ${errorMessage}`);
       console.error("Ошибка при продаже игрока:", error);
+    } finally {
+      closeSellMenu();
     }
   }
 
@@ -101,7 +122,7 @@ export default function TeamPage({ user, logoutHandler, updateUserCoins }) {
                         user={user}
                         player={teamMember.player}
                         shop={false}
-                        sellPlayer={sellPlayer}
+                        openSellMenu={openSellMenu}
                       />
                     </div>
                   </div>
@@ -112,6 +133,34 @@ export default function TeamPage({ user, logoutHandler, updateUserCoins }) {
           </div>
         </div>
       </div>
+      {isMenuOpen && playerToSell && (
+               <div className={styles.overlay} onClick={handleClickOutside}>
+              <div className={styles.menu}>
+                <h3>Внимание!</h3>
+                <p>
+                  Вы подтверждаете продажу игрока <b>{playerToSell.nickname}</b>?
+                </p>
+                <p>
+                  Коммисия за продажу составит 2% —{" "}
+                  {formatNumberWithSpaces(
+                    Math.ceil((playerToSell.costcoins / 100) * 2)
+                  )}{" "}
+                  монет
+                </p>
+                <div className={styles.centerMode}>
+                  <button
+                    className={styles.menuButtonYes}
+                    onClick={sellPlayer}
+                  >
+                    Да
+                  </button>
+                  <button className={styles.menuButtonNo} onClick={closeSellMenu}>
+                    Нет
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
     </>
   );
 }

--- a/client/src/components/pages/Account/TeamPage.module.css
+++ b/client/src/components/pages/Account/TeamPage.module.css
@@ -208,3 +208,62 @@ h1 {
     gap: 40px;
   }
 }
+
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5); /* Полупрозрачный чёрный */
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000; /* Убедитесь, что меню поверх других элементов */
+}
+
+/* Стили для меню */
+.menu {
+  background-color: rgb(27, 27, 27);
+  padding: 30px;
+  border-radius: 10px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+  position: relative;
+  width: 300px;
+  box-sizing: border-box;
+}
+
+/* Стили для кнопки меню в всплывашке */
+.menuButtonYes {
+  padding: 10px 20px;
+  font-size: 16px;
+  cursor: pointer;
+  background-color: #007bff;
+  color: white;
+  border: none;
+  border-radius: 5px;
+  width: 80px;
+}
+
+.menuButtonNo {
+  padding: 10px 20px;
+  font-size: 16px;
+  cursor: pointer;
+  background-color: #007bff;
+  color: white;
+  border: none;
+  border-radius: 5px;
+  width: 80px;
+}
+
+.menuButtonNo:hover, .menuButtonYes:hover {
+  background-color: #1d14cd;
+}
+
+.centerMode {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  width: 200px;
+  margin: 40px auto 10px;
+}

--- a/client/src/components/ui/Cards/Cards2.module.css
+++ b/client/src/components/ui/Cards/Cards2.module.css
@@ -145,32 +145,6 @@
   font-family: "Montserrat", sans-serif;
 }
 
-
-
-.overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background-color: rgba(0, 0, 0, 0.5); /* Полупрозрачный чёрный */
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 1000; /* Убедитесь, что меню поверх других элементов */
-}
-
-/* Стили для меню */
-.menu {
-  background-color: rgb(27, 27, 27);
-  padding: 30px;
-  border-radius: 10px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-  position: relative;
-  width: 300px;
-  box-sizing: border-box;
-}
-
 .sellButton {
   background-color: #000;
   width: 144px;
@@ -204,41 +178,6 @@
   flex-direction: row;
   justify-content: center;
   align-items: center;
-}
-
-/* Стили для кнопки меню в всплывашке */
-.menuButtonYes {
-  padding: 10px 20px;
-  font-size: 16px;
-  cursor: pointer;
-  background-color: #007bff;
-  color: white;
-  border: none;
-  border-radius: 5px;
-  width: 80px;
-}
-
-.menuButtonNo {
-  padding: 10px 20px;
-  font-size: 16px;
-  cursor: pointer;
-  background-color: #007bff;
-  color: white;
-  border: none;
-  border-radius: 5px;
-  width: 80px;
-}
-
-.menuButtonNo:hover, .menuButtonYes:hover {
-  background-color: #1d14cd;
-}
-
-.centerMode {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  width: 200px;
-  margin: 40px auto 10px;
 }
 
 h3 {

--- a/client/src/components/ui/Cards/ShopCard2.jsx
+++ b/client/src/components/ui/Cards/ShopCard2.jsx
@@ -1,4 +1,3 @@
-import { useState, useContext } from "react";
 import PropTypes from "prop-types";
 import styles from "src/components/ui/Cards/Cards2.module.css";
 
@@ -15,8 +14,7 @@ import faceGray from "src/components/ui/Cards/grayFace.svg";
 import buyImage from "src/components/ui/Cards/buy2x.png";
 import closeBuyImage from "src/components/ui/Cards/close2x.png";
 import coinsImage from "src/components/ui/Nav/coins.png";
-
-import { UtilsContext } from "src/context";
+import { formatNumberWithSpaces } from 'src/utils';
 
 export default function ShopCard2({
   user,
@@ -24,29 +22,8 @@ export default function ShopCard2({
   shop,
   buyPlayer,
   isInTeam,
-  sellPlayer,
+  openSellMenu,
 }) {
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-
-  //Подключение utils из контекста
-  const { formatNumberWithSpaces } = useContext(UtilsContext);
-
-  const handleClickOutside = (event) => {
-    if (event.target.classList.contains(styles.overlay)) {
-      setIsMenuOpen(false);
-    }
-  };
-
-  const toggleMenu = () => {
-    setIsMenuOpen(!isMenuOpen);
-    console.log(`Меню изменило состояние, сейчас оно ${isMenuOpen}`);
-  };
-
-  const sellHandler = () => {
-    sellPlayer(player.id, user.id);
-    toggleMenu();
-  };
-
   const getColorByStars = (stars) => {
     switch (stars) {
       case 1:
@@ -146,7 +123,7 @@ export default function ShopCard2({
       {!shop && (
         <>
           <div className={styles.sell}>
-            <button className={styles.sellButton} onClick={toggleMenu}>
+            <button className={styles.sellButton} onClick={() => openSellMenu(player)}>
               <div style={{ paddingRight: "10px" }}>Продать:</div>
               <img
                 src={coinsImage}
@@ -158,34 +135,6 @@ export default function ShopCard2({
               </div>
             </button>
           </div>
-          {isMenuOpen && (
-            <div className={styles.overlay} onClick={handleClickOutside}>
-              <div className={styles.menu}>
-                <h3>Внимание!</h3>
-                <p>
-                  Вы подтверждаете продажу игрока <b>{player.nickname}</b>?
-                </p>
-                <p>
-                  Коммисия за продажу составит 2% —{" "}
-                  {formatNumberWithSpaces(
-                    Math.ceil((player.costcoins / 100) * 2)
-                  )}{" "}
-                  монет
-                </p>
-                <div className={styles.centerMode}>
-                  <button
-                    className={styles.menuButtonYes}
-                    onClick={sellHandler}
-                  >
-                    Да
-                  </button>
-                  <button className={styles.menuButtonNo} onClick={toggleMenu}>
-                    Нет
-                  </button>
-                </div>
-              </div>
-            </div>
-          )}
         </>
       )}
     </>
@@ -199,4 +148,5 @@ ShopCard2.propTypes = {
   buyPlayer: PropTypes.func,
   isInTeam: PropTypes.bool,
   sellPlayer: PropTypes.func,
+  openSellMenu: PropTypes.func
 };

--- a/client/src/components/ui/Cards/StarsComponent/StarsComponent.jsx
+++ b/client/src/components/ui/Cards/StarsComponent/StarsComponent.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import starFullImage from "src/components/ui/Cards/StarsComponent/star2.svg";
 import starEmptyImage from "src/components/ui/Cards/StarsComponent/emptystar2.svg";
 


### PR DESCRIPTION
- Убрал код модалки (тут она называется menu) продажи игрока из компонента карточки и перенес его на страницу команды. Раньше было - если 100 карточек, то и 100 дубликатов этой модалки! Это влияет на производительность
- Переименовал пару переменных и убрал лишние логирования/комменты
- Далее необходимо еще сильнее облегчить карточку игрока. Там очень много элементов - div'ы в div'ах, img и все такое. Особенно беспокоит StarsComponent. В идеале карточку можно уменьшить до двух-трех картинок и пары строчек текста. Если прям вообще заморочиться - полностью генерировать карточку в виде картинки на бэке и присылать на фронт при запросе