### PR TITLE
Fix cookie lifetime and token expiration

### DIFF
--- a/server/src/configs/cookieConfig.js
+++ b/server/src/configs/cookieConfig.js
@@ -1,9 +1,7 @@
-const jwtConfig = require("./jwtConfig");
-
+// Lifetime for refresh token cookie (12 hours)
 const cookieConfig = {
   httpOnly: true,
-  maxAge: jwtConfig.refresh.expiresIn,
-  // Поля ниже могут пригодиться, если браузер не выписывает куки
+  maxAge: 12 * 60 * 60 * 1000,
   // secure: true,
   // sameSite: 'strict',
 };

--- a/server/src/configs/jwtConfig.js
+++ b/server/src/configs/jwtConfig.js
@@ -1,9 +1,11 @@
 const jwtConfig = {
+  // access token expires in 5 minutes
   access: {
-    expiresIn: `${5000}`,
+    expiresIn: '5m',
   },
+  // refresh token expires in 12 hours
   refresh: {
-    expiresIn: `${1000 * 60 * 60 * 12}`,
+    expiresIn: '12h',
   },
 };
 


### PR DESCRIPTION
## Summary
- fix JWT config to use string durations
- ensure cookie maxAge is numeric

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68489e8b9d3c833297397d47643cf532